### PR TITLE
Adding simpler cpustats

### DIFF
--- a/bcmstat.sh
+++ b/bcmstat.sh
@@ -1405,7 +1405,7 @@ def main(args):
       COLOUR = False
     elif a1 == "d":
       DELAY = int(a2)
-    elif a1 == "H": 
+    elif a1 == "H":
       HDREVERY = int(a2)
 
     elif a1 == "i":


### PR DESCRIPTION
For basic monitoring I found the x flag CPU stats to be too detailed and caused the display to wrap on my preferred screen size; I've added an additional flag to display simpler stats which include just:

%user	%nice	%sys+	%total

(I combined the hardware/software system interrupts and i/o wait times into %sys+ and removed %idle)

It's a bit rough (duplicated and adapted the x/X code) so it'll error if used simultaneously with x/X.