### PR TITLE
fix for libreelec 12.0.2

### DIFF
--- a/bcmstat.sh
+++ b/bcmstat.sh
@@ -369,6 +369,8 @@ def vcgencmd(args, split=True):
 def vcgencmd_items(args, isInt=False):
   d = {}
   for l in [x.split("=") for x in vcgencmd(args, split=False).split("\n")]:
+    if len(l) < 2:
+      continue
     if not isInt:
       d[l[0]] = l[1]
     elif l[1][:2] == "0x":


### PR DESCRIPTION
After the update to libreelec 12.0.2. I was getting an error on start:


```bash
Traceback (most recent call last):
  File "/usr/bin/bcmstat.sh", line 1708, in <module>
    main(sys.argv[1:])
  File "/usr/bin/bcmstat.sh", line 1565, in main
    sysinfo = getsysinfo(HARDWARE)
              ^^^^^^^^^^^^^^^^^^^^
  File "/usr/bin/bcmstat.sh", line 770, in getsysinfo
    VCG_INT = vcgencmd_items("get_config int", isInt=True)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/bin/bcmstat.sh", line 375, in vcgencmd_items
    elif l[1][:2] == "0x":
         ~^^^
IndexError: list index out of range

```

This PR fixes the issue so the script is runnable again. It looks that the values are displayed as before. A bit more debug shown that the case where `l` has length less than 2 are: 

```
['ioctl_set_msg failed:-1']
['get_config int']
['ioctl_set_msg failed:-1']
['get_config int']
```

This is on an Rpi3